### PR TITLE
feat: add md lint step to cyclic skills; suppress MD036

### DIFF
--- a/.claude/skills/fix-specs/SKILL.md
+++ b/.claude/skills/fix-specs/SKILL.md
@@ -82,11 +82,21 @@ Apply fixes one at a time, updating the spec file after each. Do not batch multi
 
 If two agents make conflicting recommendations for the same issue, explicitly note the conflict, reason about the best resolution, and apply the most appropriate fix.
 
-### Step 5 — Re-review
+### Step 5 — Markdown lint check
 
-After all fixes from this round are applied, go back to **Step 2** and run all agents again on the updated spec.
+After all fixes from this round are applied, run the markdown linter:
 
-### Step 6 — Completion check
+```bash
+markdownlint 'architecture/**/*.md' 'implementation/*.md' 'CLAUDE.md'
+```
+
+If the linter exits with errors, fix every reported violation before continuing. Re-run until the linter exits zero. Only then proceed to Step 6.
+
+### Step 6 — Re-review
+
+After all fixes are applied and the linter is clean, go back to **Step 2** and run all agents again on the updated spec.
+
+### Step 7 — Completion check
 
 After each review round, check: **did every agent report NO ISSUES for CRITICAL and HIGH severity?**
 

--- a/.claude/skills/plan-fix-spec/SKILL.md
+++ b/.claude/skills/plan-fix-spec/SKILL.md
@@ -122,11 +122,21 @@ Run Track A and Track B in parallel where possible. If a plan fix depends on a s
 
 If two agents make conflicting recommendations for the same issue, surface the conflict explicitly, reason about the best resolution, and apply the most appropriate fix.
 
-### Step 5 — Clear context and re-review
+### Step 5 — Markdown lint check
 
-After all fixes from this round are applied, run `/clear` to reset the context window, then return to **Step 2** and run all 9 agents again on the updated plan and specs.
+After all fixes from this round are applied, run the markdown linter:
 
-### Step 6 — Completion check
+```bash
+markdownlint 'architecture/**/*.md' 'implementation/*.md' 'CLAUDE.md'
+```
+
+If the linter exits with errors, fix every reported violation before continuing. Re-run until the linter exits zero. Only then proceed to Step 6.
+
+### Step 6 — Clear context and re-review
+
+After all fixes are applied and the linter is clean, run `/clear` to reset the context window, then return to **Step 2** and run all 9 agents again on the updated plan and specs.
+
+### Step 7 — Completion check
 
 After each review round, check: **did every agent report NO CRITICAL or HIGH issues in their domain (for the targeted phases)?**
 

--- a/.claude/skills/plan-spec/SKILL.md
+++ b/.claude/skills/plan-spec/SKILL.md
@@ -84,11 +84,21 @@ For each CRITICAL or HIGH issue (CRITICAL first):
 
 If two agents make conflicting recommendations for the same issue, surface the conflict explicitly, reason about the best resolution, and apply the most appropriate fix.
 
-### Step 5 — Re-review
+### Step 5 — Markdown lint check
 
-After all fixes are applied, return to **Step 2** and run all 9 agents again on the updated plan.
+After all fixes are applied, run the markdown linter:
 
-### Step 6 — Completion check
+```bash
+markdownlint 'architecture/**/*.md' 'implementation/*.md' 'CLAUDE.md'
+```
+
+If the linter exits with errors, fix every reported violation before continuing. Re-run until the linter exits zero. Only then proceed to Step 6.
+
+### Step 6 — Re-review
+
+After all fixes are applied and the linter is clean, return to **Step 2** and run all 9 agents again on the updated plan.
+
+### Step 7 — Completion check
 
 After each review round, check: **did every agent report NO CRITICAL or HIGH issues?**
 

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,6 +3,7 @@
   "MD013": false,
   "MD033": false,
   "MD041": false,
+  "MD036": false,
   "MD060": false,
   "MD024": { "siblings_only": true },
   "MD029": false


### PR DESCRIPTION
## Summary

- `fix-specs`, `plan-spec`, `plan-fix-spec` skills: insert a markdown lint check step between "fix issues" and "re-review" in each iterative cycle — linter must exit zero before the next round begins
- `.markdownlint.json`: suppress MD036 (`no-emphasis-as-heading`) — the `**Status: DONE**` / `**Status: IN PROGRESS**` convention in phase files is intentional and will appear across all 10 phase files

🤖 Generated with [Claude Code](https://claude.com/claude-code)