### PR TITLE
build(deps): add nlohmann-json to vcpkg.json (Phase 11q2 prep)

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,7 @@
     "fmt",
     "glew",
     "gtest",
-    "rapidcheck"
+    "rapidcheck",
+    "nlohmann-json"
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `nlohmann-json` to `vcpkg.json` dependencies array
- **This is a preparatory PR only** — no code changes, just the dependency declaration

## Why

Phase 11q2 migrates `CitySimulation.cpp` from a hand-rolled JSON parser to `nlohmann/json`. Linux CI runs with `VCPKG_MANIFEST_INSTALL=OFF` and relies on packages baked into the CI Docker image at build time. Without a rebuilt image, `find_package(nlohmann_json)` will fail in `build-linux`, `test-linux`, and `coverage-linux` jobs.

Merging this PR to `develop` auto-triggers `docker-ci-image.yml` (it watches `vcpkg.json` on `main`/`develop`), which will publish a new CI base image with `nlohmann-json` pre-installed.

## Pre-checks performed

- ✅ `docker/ci-linux/Dockerfile` uses vcpkg manifest mode (`COPY vcpkg.json` + `vcpkg install`) — no explicit port list to update
- ✅ `nlohmann-json` port exists at `msvc.yml` `VCPKG_COMMIT_ID` `b2f068f` (verified via GitHub API) — no baseline bump needed

## After merging

1. `docker-ci-image.yml` auto-triggers and prints the new `sha256:` digest in Step 9
2. Update digest pins in the follow-up Phase 11q2 PR:
   - `.devcontainer/Dockerfile` FROM line
   - `.github/workflows/_build-linux.yml:25`
   - `.github/workflows/_coverage-linux.yml:22`
   - `.github/workflows/_test-linux.yml:40`

🤖 Generated with [Claude Code](https://claude.com/claude-code)