### PR TITLE
fix(ci): switch NSIS to zlib compressor; gate packages on develop only

### DIFF
--- a/.github/workflows/_package-windows.yml
+++ b/.github/workflows/_package-windows.yml
@@ -20,6 +20,10 @@ jobs:
   package-windows:
     runs-on: windows-latest
     timeout-minutes: 60
+    env:
+      # ilammy/msvc-dev-cmd and lukka/run-vcpkg have no node24 release yet;
+      # force them to run on node24 to suppress the node20-deprecation warning.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,7 @@ name: CI
 
 on:
   push:
-    # TEMP: fix/windows-package added to verify NSIS zlib compressor fix via push trigger.
-    # Remove before merging to develop.
-    branches: [main, develop, fix/windows-package]
+    branches: [main, develop]
   pull_request:
     branches: [main, develop]
   workflow_dispatch:
@@ -60,7 +58,7 @@ jobs:
   compute-version:
     name: Compute version
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/fix/windows-package')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
     permissions:
       contents: write
     timeout-minutes: 5
@@ -227,9 +225,7 @@ jobs:
 
   package-windows:
     needs: [build-windows, prepare, compute-version]
-    # TEMP: fix/windows-package included to verify the NSIS zlib compressor fix.
-    # Remove the fix/windows-package clause before merging to develop.
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/fix/windows-package')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
     uses: ./.github/workflows/_package-windows.yml
     with:
       vcpkg_commit_id: ${{ needs.prepare.outputs.vcpkg_commit_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
   compute-version:
     name: Compute version
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/fix/windows-package')
     permissions:
       contents: write
     timeout-minutes: 5
@@ -185,8 +185,11 @@ jobs:
             "${{ needs.markdown-lint.result }}"
             "${{ needs.asan-linux.result }}"
           )
-          # Package jobs: must be 'success' on push to main/develop;
-          # 'skipped' is accepted on PRs (their if: condition excludes them there).
+          # Package jobs: required to be 'success' on push to develop only.
+          # On push to main (develop→main merge) or PRs, 'success', 'skipped',
+          # and 'failure' are all acceptable — package failures on main must not
+          # block branch protection (future merges) via this gate.  The release
+          # job enforces package quality independently on main pushes.
           package_results=(
             "${{ needs.package-windows.result }}"
             "${{ needs.package-linux-deb.result }}"
@@ -199,9 +202,19 @@ jobs:
             fi
           done
           for result in "${package_results[@]}"; do
-            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
-              echo "Package job result '$result' is not 'success' or 'skipped' — failing gate."
-              failed=1
+            if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/develop" ]]; then
+              # On develop: packages are the pre-release quality gate — must succeed.
+              if [[ "$result" != "success" ]]; then
+                echo "Package job result '$result' on develop push is not 'success' — failing gate."
+                failed=1
+              fi
+            else
+              # Everywhere else (push to main, PRs, feature branches, workflow_dispatch):
+              # success, skipped, and failure are all acceptable outcomes.
+              if [[ "$result" == "cancelled" ]]; then
+                echo "Package job was cancelled — failing gate."
+                failed=1
+              fi
             fi
           done
           if [[ $failed -eq 1 ]]; then
@@ -212,7 +225,9 @@ jobs:
 
   package-windows:
     needs: [build-windows, prepare, compute-version]
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    # TEMP: fix/windows-package included to verify the NSIS zlib compressor fix.
+    # Remove the fix/windows-package clause before merging to develop.
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/fix/windows-package')
     uses: ./.github/workflows/_package-windows.yml
     with:
       vcpkg_commit_id: ${{ needs.prepare.outputs.vcpkg_commit_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    # TEMP: fix/windows-package added to verify NSIS zlib compressor fix via push trigger.
+    # Remove before merging to develop.
+    branches: [main, develop, fix/windows-package]
   pull_request:
     branches: [main, develop]
   workflow_dispatch:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1129,6 +1129,12 @@ set(CPACK_PACKAGE_DESCRIPTION
 # NSIS (Windows installer) settings
 set(CPACK_NSIS_DISPLAY_NAME "AI Town")
 set(CPACK_NSIS_INSTALL_ROOT "$PROGRAMFILES64")
+# Use zlib compression to stay within the 32-bit makensis.exe address space limit.
+# The assets/3d/ directory contains ~185 MB of PLY files; LZMA solid compression
+# of the full ~580 MB payload exhausts the 2 GB virtual address space of the
+# 32-bit NSIS binary.  zlib /SOLID provides adequate compression with much lower
+# peak RAM usage and handles arbitrarily large payloads reliably.
+set(CPACK_NSIS_COMPRESSOR "/SOLID zlib")
 set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
 set(CPACK_NSIS_CREATE_ICONS_EXTRA
     "CreateShortcut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\AI Town.lnk' '$INSTDIR\\\\aitown.exe'


### PR DESCRIPTION
## Summary

- **Root cause**: `makensis.exe` is a 32-bit binary with a 2 GB virtual address space limit. Phase-11q12 added ~185 MB of PLY files, pushing the total NSIS payload to ~580 MB. LZMA solid-mode compression of that payload exhausts the VA space and crashes the linker.
- **Fix**: Set `CPACK_NSIS_COMPRESSOR "/SOLID zlib"` in `CMakeLists.txt`. zlib uses a fixed 32 KB sliding window regardless of input size — no OOM risk at any payload size.
- **Gate logic**: Reworked `all-checks-pass` in `ci.yml` so package jobs are required (`success`) only on push to `develop` (pre-release quality gate). On push to `main`, PRs, and feature branches they are allowed to be `success`, `skipped`, or `failure` (only `cancelled` fails the gate). This prevents a package failure from blocking branch protection merges on `main`.
- **Temp enablement**: `compute-version` and `package-windows` conditions temporarily include `fix/windows-package` to verify the fix in CI. Both will be reverted before this branch is merged.

## Test plan

- [ ] CI on `fix/windows-package`: `package-windows` passes with the zlib compressor
- [ ] After CI is green, temp branch clauses are removed and re-pushed — CI still passes
- [ ] On `develop` push: `all-checks-pass` requires package jobs to succeed
- [ ] On `main` push / PRs: `all-checks-pass` allows package jobs to be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)