### PR TITLE
refactor: replace redundant types with auto (cpp:S5827)

### DIFF
--- a/src/audio/AudioStream.cpp
+++ b/src/audio/AudioStream.cpp
@@ -26,7 +26,7 @@ bool seekToStart(OggVorbis_File* vf) noexcept {
 int decodeFrames(OggVorbis_File* vf, int16_t* pcmBuf, int maxFrames, int channels) noexcept {
     if (!vf || !pcmBuf || maxFrames <= 0 || channels <= 0) return 0;
 
-    int bytesWanted = maxFrames * channels * static_cast<int>(sizeof(int16_t));
+    auto bytesWanted = maxFrames * channels * static_cast<int>(sizeof(int16_t));
     char* buf = reinterpret_cast<char*>(pcmBuf);
     int   totalBytes = 0;
     int   bitstream  = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,7 +283,7 @@ static bool runFrame(AppSystems& sys) {
 
     // Compute real delta — computed ONCE per frame, BEFORE step 2.
     const double currentTime  = sys.wallClock.nowSeconds();
-    const float  realDeltaSeconds = static_cast<float>(currentTime - sys.prevTime);
+    const auto  realDeltaSeconds = static_cast<float>(currentTime - sys.prevTime);
     sys.prevTime = currentTime;
 
     // Step 1: Poll events — handled by EventReceiver::OnEvent() via device->run().
@@ -433,7 +433,7 @@ static bool runFrame(AppSystems& sys) {
         double loadPrev2 = sys.wallClock.nowSeconds();
         while (device->run() && sys.terrainSystem->pendingRebuildCount() > 0) {
             const double loadNow2  = sys.wallClock.nowSeconds();
-            const float  loadDt2   = static_cast<float>(loadNow2 - loadPrev2);
+            const auto  loadDt2   = static_cast<float>(loadNow2 - loadPrev2);
             loadPrev2 = loadNow2;
             sys.uiManager->update(loadDt2);
             sys.terrainSystem->update(loadDt2);
@@ -486,7 +486,7 @@ static bool runFrame(AppSystems& sys) {
             double loadPrevL = sys.wallClock.nowSeconds();
             while (device->run() && sys.terrainSystem->pendingRebuildCount() > 0) {
                 const double loadNowL  = sys.wallClock.nowSeconds();
-                const float  loadDtL   = static_cast<float>(loadNowL - loadPrevL);
+                const auto  loadDtL   = static_cast<float>(loadNowL - loadPrevL);
                 loadPrevL = loadNowL;
                 sys.uiManager->update(loadDtL);
                 sys.terrainSystem->update(loadDtL);

--- a/src/rendering/IrrlichtRenderer.cpp
+++ b/src/rendering/IrrlichtRenderer.cpp
@@ -765,8 +765,8 @@ bool IrrlichtRenderer::pickTerrainTile(int screenX, int screenY,
     if (std::fabs(rd.Y) < 1e-5f) return false;
 
     // ---- DDA Step 1: Starting tile (clamp to map) ----
-    int cx = static_cast<int>(ro.X / m_cellSize);
-    int cz = static_cast<int>(ro.Z / m_cellSize);
+    auto cx = static_cast<int>(ro.X / m_cellSize);
+    auto cz = static_cast<int>(ro.Z / m_cellSize);
     cx = std::max(0, std::min(cx, m_mapTilesX - 1));
     cz = std::max(0, std::min(cz, m_mapTilesZ - 1));
 
@@ -1210,8 +1210,8 @@ void IrrlichtRenderer::setZoneOverlay(
         if (written >= kMaxOverlayQuads) break;
 
         // Decode tile index from key.
-        int tx = static_cast<int>(kv.first % mapTilesX);
-        int tz = static_cast<int>(kv.first / mapTilesX);
+        auto tx = static_cast<int>(kv.first % mapTilesX);
+        auto tz = static_cast<int>(kv.first / mapTilesX);
 
         // Skip out-of-bounds tiles.
         if (tx < 0 || tx >= mapTilesX || tz < 0 || tz >= mapTilesZ) continue;
@@ -1321,8 +1321,8 @@ ScreenRect IrrlichtRenderer::getTileScreenBounds(int tileX, int tileZ) const
 
         // Convert NDC to pixel coordinates.
         // NDC (+1,-1) = top-left in most conventions; Irrlicht uses Y-down screen.
-        int sx = static_cast<int>((ndcX  + 1.0f) * 0.5f * static_cast<float>(screenSize.Width));
-        int sy = static_cast<int>((1.0f - ndcY) * 0.5f * static_cast<float>(screenSize.Height));
+        auto sx = static_cast<int>((ndcX  + 1.0f) * 0.5f * static_cast<float>(screenSize.Width));
+        auto sy = static_cast<int>((1.0f - ndcY) * 0.5f * static_cast<float>(screenSize.Height));
 
         minX = std::min(minX, sx);
         minY = std::min(minY, sy);
@@ -1739,7 +1739,7 @@ bool IrrlichtRenderer::initRoadShader()
 
     // srgbOk drives u_srgbLinear in the callback (0 when sRGB, 1 when linear upload).
     // road.frag uses this to decide whether to apply the linear→sRGB inverse correction.
-    RoadShaderCallback* cb = new RoadShaderCallback(srgbOk, texHandle);
+    auto* cb = new RoadShaderCallback(srgbOk, texHandle);
     s32 matType = gpu->addHighLevelShaderMaterialFromFiles(
         vsPath.c_str(), "main", video::EVST_VS_1_1,
         fsPath.c_str(), "main", video::EPST_PS_1_1,
@@ -1813,7 +1813,7 @@ void IrrlichtRenderer::initTerrainShader()
     };
 
     // Construct callback — raw heap per shader-loading.md (Irrlicht calls grab() internally).
-    TerrainShaderCallback* cb = new TerrainShaderCallback(
+    auto* cb = new TerrainShaderCallback(
         m_renderSystem, m_terrainTextureCache.get(), splatPath, detailPaths);
 
     // Build absolute shader paths.
@@ -2774,7 +2774,7 @@ static SMesh* buildCloudDomeMesh()
     SMesh*       mesh = new SMesh();
     SMeshBuffer* buf  = new SMeshBuffer();
 
-    const float piF = static_cast<float>(M_PI);
+    const auto piF = static_cast<float>(M_PI);
 
     // -----------------------------------------------------------------------
     // Vertex 0: shared apex (single vertex, no degenerate triangles at the top).
@@ -2932,7 +2932,7 @@ void IrrlichtRenderer::initCloudPlane()
             // Irrlicht also calls grab() internally on the passed pointer.  The caller's
             // reference is dropped in IrrlichtRenderer::~IrrlichtRenderer().
             // Never std::unique_ptr — causes double-free (see CLAUDE.md shader callbacks).
-            CloudDomeShaderCallback* cb = new CloudDomeShaderCallback();
+            auto* cb = new CloudDomeShaderCallback();
             irr::s32 matType = gpu->addHighLevelShaderMaterialFromFiles(
                 vsPath.c_str(), "main", irr::video::EVST_VS_1_1,
                 fsPath.c_str(), "main", irr::video::EPST_PS_1_1,
@@ -3166,8 +3166,8 @@ void IrrlichtRenderer::moveVehicleAgent(AgentHandle handle, float worldX, float 
 
     // Sample bilinear terrain height at world position + road surface bias.
     float y = 0.0f;
-    int tileX = static_cast<int>(worldX / kTileSize);
-    int tileZ = static_cast<int>(worldZ / kTileSize);
+    auto tileX = static_cast<int>(worldX / kTileSize);
+    auto tileZ = static_cast<int>(worldZ / kTileSize);
     if (m_terrain) {
         const float rawHeight = m_terrain->getHeightAtWorld(worldX, worldZ);
         y = rawHeight + kRoadSurfaceYBias;

--- a/src/rendering/VRAMProfiler.cpp
+++ b/src/rendering/VRAMProfiler.cpp
@@ -45,7 +45,7 @@ float VRAMProfiler::usedMB() const
         glGetIntegerv(GL_GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX, &totalKB);
         glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, &availKB);
         if (totalKB <= 0) { return -1.0f; }
-        float usedKB = static_cast<float>(totalKB - availKB);
+        auto usedKB = static_cast<float>(totalKB - availKB);
         return usedKB / 1024.0f;
     }
     case Method::ATI:

--- a/src/simulation/CitySimulation.cpp
+++ b/src/simulation/CitySimulation.cpp
@@ -244,7 +244,7 @@ void CitySimulation::recordUndoAction(const UndoAction& action) {
 
     float sv = speedValue(m_timing.getSpeedMultiplier());
     if (sv > 0.0f) {
-        double realSecondsRemaining = static_cast<double>(
+        auto realSecondsRemaining = static_cast<double>(
             (2.0f * SimulationConstants::SECONDS_PER_BUDGET_TICK - m_timing.m_accumulatedSimSeconds) / sv);
         m_undoExpiryWallSeconds = m_clock->nowSeconds() + realSecondsRemaining;
     } else {
@@ -410,8 +410,8 @@ void CitySimulation::placeZone(int tileX, int tileZ, ZoneType type, DensityTier 
 
     // Variant counter + deferred mesh spawn.
     {
-        int zoneIdx = static_cast<int>(type);
-        int tierIdx = static_cast<int>(tier);
+        auto zoneIdx = static_cast<int>(type);
+        auto tierIdx = static_cast<int>(tier);
         int idx     = zoneIdx * 3 + tierIdx;
         m_zoning.m_buildingVariantCounters[idx]++;
         int variantNum = ((m_zoning.m_buildingVariantCounters[idx] - 1) % 4) + 1;
@@ -843,8 +843,8 @@ std::string CitySimulation::serializeToJson() const {
 
     nlohmann::json tilesArr = nlohmann::json::array();
     for (const auto& [key, tile] : m_zoning.m_tiles) {
-        int tx = static_cast<int>(key >> 32);
-        int tz = static_cast<int>(static_cast<uint32_t>(key & 0xFFFFFFFFLL));
+        auto tx = static_cast<int>(key >> 32);
+        auto tz = static_cast<int>(static_cast<uint32_t>(key & 0xFFFFFFFFLL));
         nlohmann::json tobj;
         tobj["x"] = tx;
         tobj["z"] = tz;

--- a/src/simulation/Economy.cpp
+++ b/src/simulation/Economy.cpp
@@ -223,7 +223,7 @@ void Economy::checkAndIssueForcedLoan(bool inGracePeriod, IClock& /*clock*/,
     }
 
     float revenueCap = std::max(m_currentMonthlyRevenue, 1000.0f);
-    int64_t debtCap = static_cast<int64_t>(3.0f * revenueCap);
+    auto debtCap = static_cast<int64_t>(3.0f * revenueCap);
 
     if (outstandingDebt >= debtCap) {
         if (m_outstandingBondUses > 0) {
@@ -324,7 +324,7 @@ void Economy::processLoanRepayments() {
 // ---------------------------------------------------------------------------
 
 int64_t Economy::computeTaxRevenue(ZoneType zone, const Zoning& zoning, const Traffic& traffic) const {
-    int zoneIdx = static_cast<int>(zone);
+    auto zoneIdx = static_cast<int>(zone);
     float taxRate = m_taxRates[zoneIdx];
 
     auto incomeForDensity = [](DensityTier d) -> int {
@@ -339,7 +339,7 @@ int64_t Economy::computeTaxRevenue(ZoneType zone, const Zoning& zoning, const Tr
     int64_t total = 0;
     for (auto& [key, tile] : zoning.tiles()) {
         if (!tile.isZoned || tile.zone != zone) continue;
-        int pop = static_cast<int>(tile.population);
+        auto pop = static_cast<int>(tile.population);
         int income = incomeForDensity(tile.density);
         total += static_cast<int64_t>(static_cast<float>(income * pop) * taxRate);
     }
@@ -414,8 +414,8 @@ int64_t Economy::computeUtilityFeeRevenue(const Zoning& zoning) const {
     for (auto& [key, tile] : zoning.tiles()) {
         if (!tile.isZoned || tile.zone != ZoneType::Residential) continue;
 
-        int x = static_cast<int>(key >> 32);
-        int z = static_cast<int>(static_cast<uint32_t>(key));
+        auto x = static_cast<int>(key >> 32);
+        auto z = static_cast<int>(static_cast<uint32_t>(key));
 
         if (hasPower) {
             if (zoning.isPowerCovered(x, z)) {

--- a/src/simulation/Population.cpp
+++ b/src/simulation/Population.cpp
@@ -184,8 +184,8 @@ void Population::accumulateHouseDemand(const Zoning& zoning,
     float effective_demand_factor = traffic.getZoneDemandFactor(tile.zone);
     if (effective_demand_factor >= SimulationConstants::construction_delay_demand_threshold) {
         tile.underConstruction = false;
-        int tileX = static_cast<int>(key >> 32);
-        int tileZ = static_cast<int>(static_cast<uint32_t>(key));
+        auto tileX = static_cast<int>(key >> 32);
+        auto tileZ = static_cast<int>(static_cast<uint32_t>(key));
         std::string baseName = Zoning::zoneAssetBaseName(tile.zone, tile.density);
         int variantNum = tile.buildingVariantNum;
         if (baseName.size() >= 2 && variantNum >= 1 && variantNum <= 4) {
@@ -232,8 +232,8 @@ Population::scanUnlockCandidates(const Zoning& zoning, ZoneType targetZone,
         if (tile.zone != targetZone) continue;
         if (tile.density != currentRequired) continue;
         if (tile.footprintOriginX != -1) continue;
-        int tx = static_cast<int>(key >> 32);
-        int tz = static_cast<int>(static_cast<uint32_t>(key & 0xFFFFFFFFLL));
+        auto tx = static_cast<int>(key >> 32);
+        auto tz = static_cast<int>(static_cast<uint32_t>(key & 0xFFFFFFFFLL));
         candidates.push_back({key, tx, tz});
     }
     return candidates;
@@ -405,7 +405,7 @@ bool Population::applyDensityUpgrade(Zoning& zoning, int tx, int tz, int64_t can
 
     for (auto& ot : outerTiles) {
         if (!renderer) break;
-        int zoneIdx = static_cast<int>(ot.zone);
+        auto zoneIdx = static_cast<int>(ot.zone);
         int idx = zoneIdx * 3 + 0;
         zoning.m_buildingVariantCounters[idx]++;
         int variantNum = ((zoning.m_buildingVariantCounters[idx] - 1) % 4) + 1;
@@ -426,8 +426,8 @@ bool Population::applyDensityUpgrade(Zoning& zoning, int tx, int tz, int64_t can
 
     // Place upgraded building mesh (after notifyUpgradeResult removes the old one).
     if (renderer) {
-        int zoneIdx2 = static_cast<int>(targetZone);
-        int tierIdx2 = static_cast<int>(targetDensity);
+        auto zoneIdx2 = static_cast<int>(targetZone);
+        auto tierIdx2 = static_cast<int>(targetDensity);
         int idx2     = zoneIdx2 * 3 + tierIdx2;
         zoning.m_buildingVariantCounters[idx2]++;
         int variantNum = ((zoning.m_buildingVariantCounters[idx2] - 1) % 4) + 1;

--- a/src/simulation/Traffic.cpp
+++ b/src/simulation/Traffic.cpp
@@ -83,8 +83,8 @@ std::vector<RoadSegmentSpeed> Traffic::getRoadSegmentSpeeds(const Zoning& zoning
     speeds.reserve(m_trafficSignals.size() + 8);
     for (const auto& kv : zoning.tiles()) {
         if (!kv.second.isRoad) continue;
-        int tx = static_cast<int>(static_cast<int64_t>(kv.first) >> 32);
-        int tz = static_cast<int>(static_cast<uint32_t>(kv.first & 0xFFFFFFFFLL));
+        auto tx = static_cast<int>(static_cast<int64_t>(kv.first) >> 32);
+        auto tz = static_cast<int>(static_cast<uint32_t>(kv.first & 0xFFFFFFFFLL));
         RoadSegmentSpeed rss;
         rss.tileX = tx;
         rss.tileZ = tz;
@@ -271,8 +271,8 @@ void Traffic::spawnVehiclesForRoad(int tileX, int tileZ, int roadTileCount,
     v.srcX = tileX; v.srcZ = tileZ;
     v.dstX = dstX;  v.dstZ = dstZ;
     v.progress = 0.0f;
-    float dx = static_cast<float>(dstX - tileX);
-    float dz = static_cast<float>(dstZ - tileZ);
+    auto dx = static_cast<float>(dstX - tileX);
+    auto dz = static_cast<float>(dstZ - tileZ);
     v.headingDeg = std::atan2(dx, dz) * (180.0f / kPiF);
     v.worldX = (static_cast<float>(tileX) + 0.5f) * kTileSizeMeters;
     v.worldZ = (static_cast<float>(tileZ) + 0.5f) * kTileSizeMeters;
@@ -316,8 +316,8 @@ void Traffic::computeTrafficDemand(const Zoning& zoning, int totalTicks) {
     for (auto& [key, tile] : zoning.tiles()) {
         if (!tile.isZoned) continue;
 
-        int x = static_cast<int>(key >> 32);
-        int z = static_cast<int>(static_cast<uint32_t>(key));
+        auto x = static_cast<int>(key >> 32);
+        auto z = static_cast<int>(static_cast<uint32_t>(key));
 
         bool hasRoadAdjacentTile = false;
         for (int d = 0; d < 4; ++d) {
@@ -534,8 +534,8 @@ void Traffic::doTrafficVehicleTick(float realDeltaSeconds, Zoning& zoning,
             v.dstX = nextX;
             v.dstZ = nextZ;
             v.progress -= 1.0f;
-            float dx = static_cast<float>(v.dstX - v.srcX);
-            float dz = static_cast<float>(v.dstZ - v.srcZ);
+            auto dx = static_cast<float>(v.dstX - v.srcX);
+            auto dz = static_cast<float>(v.dstZ - v.srcZ);
             v.headingDeg = std::atan2(dx, dz) * (180.0f / kPiF);
         }
         float t = std::max(0.0f, std::min(1.0f, v.progress));

--- a/src/simulation/Zoning.cpp
+++ b/src/simulation/Zoning.cpp
@@ -71,8 +71,8 @@
         { "com_low",  "com_med",  "com_high"  },
         { "ind_low",  "ind_med",  "ind_high"  },
     };
-    int zi = static_cast<int>(zone);
-    int di = static_cast<int>(density);
+    auto zi = static_cast<int>(zone);
+    auto di = static_cast<int>(density);
     if (zi < 0 || zi > 2 || di < 0 || di > 2) return {};
     return std::string(kZonePrefix[zi][di]) + "_01";
 }
@@ -301,8 +301,8 @@ float Zoning::computeRadialCoverage(int tileX, int tileZ, ServiceBuildingType ty
         if (sb.type != type) continue;
         float radius = computeServiceCoverageRadius(type, sb.degraded);
         float radiusTiles = radius / kTileSizeMeters;
-        float dx = static_cast<float>(sb.x - tileX);
-        float dz = static_cast<float>(sb.z - tileZ);
+        auto dx = static_cast<float>(sb.x - tileX);
+        auto dz = static_cast<float>(sb.z - tileZ);
         float dist = std::sqrt(dx * dx + dz * dz);
         if (dist <= radiusTiles) {
             return 1.0f;
@@ -367,8 +367,8 @@ float Zoning::computePowerCoverage(int tileX, int tileZ) const {
         if (it == bfsDepth.end()) {
             float radiusTiles = computeServiceCoverageRadius(ServiceBuildingType::PowerPlant, sb.degraded)
                                 / kTileSizeMeters;
-            float fdx = static_cast<float>(tileX - sb.x);
-            float fdz = static_cast<float>(tileZ - sb.z);
+            auto fdx = static_cast<float>(tileX - sb.x);
+            auto fdz = static_cast<float>(tileZ - sb.z);
             float dist = std::sqrt(fdx * fdx + fdz * fdz);
             if (dist <= radiusTiles) return 1.0f;
             continue;
@@ -378,7 +378,7 @@ float Zoning::computePowerCoverage(int tileX, int tileZ) const {
 
         if (m_budgetSurplusPctRef <=
             SimulationConstants::service_deficit_radius_halving_threshold) {
-            int coverDepth = static_cast<int>(
+            auto coverDepth = static_cast<int>(
                 std::floor(static_cast<float>(maxDepth) * 0.70f));
             if (targetDepth > coverDepth) continue;
         }
@@ -401,8 +401,8 @@ void Zoning::addRadialFallbackCoverage(const ServiceBuilding& sb, float radiusTi
             int nz = sb.z + dz;
             int64_t nkey = tileKey(nx, nz);
             if (bfsDepth.count(nkey)) continue;
-            float fdx = static_cast<float>(dx);
-            float fdz = static_cast<float>(dz);
+            auto fdx = static_cast<float>(dx);
+            auto fdz = static_cast<float>(dz);
             if (std::sqrt(fdx * fdx + fdz * fdz) <= radiusTiles) {
                 m_powerCoverageCache.insert(nkey);
             }
@@ -620,8 +620,8 @@ void Zoning::applyDesirabilityScores(bool hasFireStation, bool hasPolice,
     for (auto& [key, tile] : m_tiles) {
         if (!tile.isZoned) continue;
 
-        int x = static_cast<int>(key >> 32);
-        int z = static_cast<int>(static_cast<uint32_t>(key));
+        auto x = static_cast<int>(key >> 32);
+        auto z = static_cast<int>(static_cast<uint32_t>(key));
 
         tile.desirability = computeTileDesirability(tile, x, z,
                                                     hasFireStation, hasPolice,
@@ -699,8 +699,8 @@ void Zoning::doProximityTick(std::queue<SimulationNotification>& notifications) 
     for (auto& [key, tile] : m_tiles) {
         if (!tile.isZoned || tile.footprintOriginX != -1) continue;
 
-        int ox = static_cast<int>(static_cast<int64_t>(key) >> 32);
-        int oz = static_cast<int>(static_cast<uint32_t>(key & 0xFFFFFFFFLL));
+        auto ox = static_cast<int>(static_cast<int64_t>(key) >> 32);
+        auto oz = static_cast<int>(static_cast<uint32_t>(key & 0xFFFFFFFFLL));
         int fp = footprintSize(tile.density);
         int dist = nearestRoadDistance(m_tiles, ox, oz, fp);
 
@@ -710,7 +710,7 @@ void Zoning::doProximityTick(std::queue<SimulationNotification>& notifications) 
             notifications.push({NotificationType::BuildingAbandoned, ox, oz, 0});
         } else if (dist <= 3 && tile.isAbandoned) {
             tile.isAbandoned = false;
-            float maxPop = static_cast<float>(maxPopulationForTile(tile.zone, tile.density));
+            auto maxPop = static_cast<float>(maxPopulationForTile(tile.zone, tile.density));
             tile.population  = maxPop * 0.5f;
             notifications.push({NotificationType::BuildingRecovered, ox, oz, 0});
         }

--- a/src/terrain/TerrainSystem.cpp
+++ b/src/terrain/TerrainSystem.cpp
@@ -310,7 +310,7 @@ void TerrainSystem::update(float /*dt*/) {
 // ---------------------------------------------------------------------------
 void TerrainSystem::flushPendingRebuilds(ITerrainLoadProgress* cb) {
     double start = m_clock ? m_clock->nowSeconds() : 0.0;
-    int total = static_cast<int>(m_rebuildDeque.size());
+    auto total = static_cast<int>(m_rebuildDeque.size());
     int done  = 0;
 
     // Per-flush deduplication set.
@@ -580,7 +580,7 @@ void TerrainSystem::buildOneChunk(int cx, int cz, int chunkTiles, float cellSize
     const int mapVertX   = m_mapTilesX + 1;        // full-map vertex width
     const int chunksX    = (m_mapTilesX + chunkTiles - 1) / chunkTiles;
 
-    uint64_t chunkId = static_cast<uint64_t>(cz * chunksX + cx);
+    auto chunkId = static_cast<uint64_t>(cz * chunksX + cx);
 
     // World-space origin of this chunk's (0,0) vertex corner.
     float worldOriginX = static_cast<float>(cx * chunkTiles) * cellSize;
@@ -749,7 +749,7 @@ void TerrainSystem::writeHeightAndSyncChunks(int tx, int tz, float h) {
 
     auto syncChunk = [&](int ccx, int ccz, int llx, int llz) {
         if (ccx < 0 || ccz < 0) return;
-        uint64_t cid = static_cast<uint64_t>(ccz * chunksX + ccx);
+        auto cid = static_cast<uint64_t>(ccz * chunksX + ccx);
         auto it = m_chunkHeightmaps.find(cid);
         if (it == m_chunkHeightmaps.end()) return;
         if (llx < 0 || llx >= chunkVerts || llz < 0 || llz >= chunkVerts) return;
@@ -913,8 +913,8 @@ float TerrainSystem::getHeightAtWorld(float worldX, float worldZ) const {
     const float tx = worldX / kTileSize;
     const float tz = worldZ / kTileSize;
 
-    const int x0 = static_cast<int>(std::floor(tx));
-    const int z0 = static_cast<int>(std::floor(tz));
+    const auto x0 = static_cast<int>(std::floor(tx));
+    const auto z0 = static_cast<int>(std::floor(tz));
     const int x1 = x0 + 1;
     const int z1 = z0 + 1;
 

--- a/src/ui/CameraController.cpp
+++ b/src/ui/CameraController.cpp
@@ -108,8 +108,8 @@ bool CameraController::handleMMBUp(const InputEvent& /*e*/) {
 }
 
 bool CameraController::handleMouseMoved(const InputEvent& e) {
-    const float dx = static_cast<float>(e.physX - m_prevPhysX);
-    const float dy = static_cast<float>(e.physY - m_prevPhysY);
+    const auto dx = static_cast<float>(e.physX - m_prevPhysX);
+    const auto dy = static_cast<float>(e.physY - m_prevPhysY);
     bool consumed = false;
 
     if (m_rmbDragActive || m_mmbDragActive) {


### PR DESCRIPTION
## Summary
- Fix all 63 SonarCloud `cpp:S5827` issues across 11 source files
- Replace explicit types with `auto` where the type is redundant (matches `static_cast<>` or `new` expression)
- Follows C++ Core Guidelines

## Files changed
AudioStream.cpp, main.cpp, IrrlichtRenderer.cpp, VRAMProfiler.cpp, CitySimulation.cpp, Economy.cpp, Population.cpp, Traffic.cpp, Zoning.cpp, TerrainSystem.cpp, CameraController.cpp

## Test plan
- [x] Build succeeds
- [x] All 1459 unit tests pass